### PR TITLE
Move `CourseIdStub` to test namespace

### DIFF
--- a/tests/Context/Course/Module/Course/Domain/CourseIdStub.php
+++ b/tests/Context/Course/Module/Course/Domain/CourseIdStub.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace CodelyTv\Shared\Test\Stub;
+declare(strict_types=1);
+
+namespace CodelyTv\Test\Context\Course\Module\Course\Domain;
 
 use CodelyTv\Shared\Domain\CourseId;
 use CodelyTv\Test\Shared\Domain\UuidStub;

--- a/tests/Context/Video/Module/Video/Application/Create/CreateVideoCommandStub.php
+++ b/tests/Context/Video/Module/Video/Application/Create/CreateVideoCommandStub.php
@@ -8,7 +8,7 @@ use CodelyTv\Context\Video\Module\Video\Domain\VideoTitle;
 use CodelyTv\Context\Video\Module\Video\Domain\VideoType;
 use CodelyTv\Context\Video\Module\Video\Domain\VideoUrl;
 use CodelyTv\Shared\Domain\CourseId;
-use CodelyTv\Shared\Test\Stub\CourseIdStub;
+use CodelyTv\Test\Context\Course\Module\Course\Domain\CourseIdStub;
 use CodelyTv\Test\Context\Video\Module\Video\Domain\VideoIdStub;
 use CodelyTv\Test\Context\Video\Module\Video\Domain\VideoTitleStub;
 use CodelyTv\Test\Context\Video\Module\Video\Domain\VideoTypeStub;

--- a/tests/Context/Video/Module/Video/Application/Create/CreateVideoTest.php
+++ b/tests/Context/Video/Module/Video/Application/Create/CreateVideoTest.php
@@ -6,6 +6,7 @@ namespace CodelyTv\Test\Context\Video\Module\Video\Application\Create;
 
 use CodelyTv\Context\Video\Module\Video\Application\Create\CreateVideoCommandHandler;
 use CodelyTv\Context\Video\Module\Video\Application\Create\VideoCreator;
+use CodelyTv\Test\Context\Course\Module\Course\Domain\CourseIdStub;
 use CodelyTv\Test\Context\Video\Module\Video\Domain\VideoCreatedDomainEventStub;
 use CodelyTv\Test\Context\Video\Module\Video\Domain\VideoIdStub;
 use CodelyTv\Test\Context\Video\Module\Video\Domain\VideoStub;
@@ -13,7 +14,6 @@ use CodelyTv\Test\Context\Video\Module\Video\Domain\VideoTitleStub;
 use CodelyTv\Test\Context\Video\Module\Video\Domain\VideoTypeStub;
 use CodelyTv\Test\Context\Video\Module\Video\Domain\VideoUrlStub;
 use CodelyTv\Test\Context\Video\Module\Video\VideoModuleUnitTestCase;
-use CodelyTv\Shared\Test\Stub\CourseIdStub;
 
 final class CreateVideoTest extends VideoModuleUnitTestCase
 {

--- a/tests/Context/Video/Module/Video/Application/Find/VideoResponseStub.php
+++ b/tests/Context/Video/Module/Video/Application/Find/VideoResponseStub.php
@@ -10,7 +10,7 @@ use CodelyTv\Context\Video\Module\Video\Domain\VideoTitle;
 use CodelyTv\Context\Video\Module\Video\Domain\VideoType;
 use CodelyTv\Context\Video\Module\Video\Domain\VideoUrl;
 use CodelyTv\Shared\Domain\CourseId;
-use CodelyTv\Shared\Test\Stub\CourseIdStub;
+use CodelyTv\Test\Context\Course\Module\Course\Domain\CourseIdStub;
 use CodelyTv\Test\Context\Video\Module\Video\Domain\VideoIdStub;
 use CodelyTv\Test\Context\Video\Module\Video\Domain\VideoTitleStub;
 use CodelyTv\Test\Context\Video\Module\Video\Domain\VideoTypeStub;

--- a/tests/Context/Video/Module/Video/Domain/VideoCreatedDomainEventStub.php
+++ b/tests/Context/Video/Module/Video/Domain/VideoCreatedDomainEventStub.php
@@ -10,7 +10,7 @@ use CodelyTv\Context\Video\Module\Video\Domain\VideoTitle;
 use CodelyTv\Context\Video\Module\Video\Domain\VideoType;
 use CodelyTv\Context\Video\Module\Video\Domain\VideoUrl;
 use CodelyTv\Shared\Domain\CourseId;
-use CodelyTv\Shared\Test\Stub\CourseIdStub;
+use CodelyTv\Test\Context\Course\Module\Course\Domain\CourseIdStub;
 
 final class VideoCreatedDomainEventStub
 {

--- a/tests/Context/Video/Module/Video/Domain/VideoStub.php
+++ b/tests/Context/Video/Module/Video/Domain/VideoStub.php
@@ -10,18 +10,24 @@ use CodelyTv\Context\Video\Module\Video\Domain\VideoTitle;
 use CodelyTv\Context\Video\Module\Video\Domain\VideoType;
 use CodelyTv\Context\Video\Module\Video\Domain\VideoUrl;
 use CodelyTv\Shared\Domain\CourseId;
-use CodelyTv\Shared\Test\Stub\CourseIdStub;
+use CodelyTv\Test\Context\Course\Module\Course\Domain\CourseIdStub;
 
 final class VideoStub
 {
+    public static function withId(VideoId $id)
+    {
+        return self::create(
+            $id,
+            VideoTypeStub::random(),
+            VideoTitleStub::random(),
+            VideoUrlStub::random(),
+            CourseIdStub::random()
+        );
+    }
+
     public static function create(VideoId $id, VideoType $type, VideoTitle $title, VideoUrl $url, CourseId $courseId)
     {
         return new Video($id, $type, $title, $url, $courseId);
-    }
-
-    public static function withId(VideoId $id)
-    {
-        return self::create($id, VideoTypeStub::random(), VideoTitleStub::random(), VideoUrlStub::random(), CourseIdStub::random());
     }
 
     public static function random(): Video


### PR DESCRIPTION
@trepix reported this issue in the CQRS CodelyTV Pro course: https://pro.codely.tv/library/cqrs-command-query-responsibility-segregation-3719e4aa/62554/path/step/33532826/discussion/78534/response/1093949/