### PR TITLE
Remove unused method

### DIFF
--- a/src/Infrastructure/Bus/Command/SymfonySyncCommandBus.php
+++ b/src/Infrastructure/Bus/Command/SymfonySyncCommandBus.php
@@ -35,11 +35,4 @@ final class SymfonySyncCommandBus implements CommandBus
             throw new CommandNotRegisteredError($command);
         }
     }
-
-    private function extractCommand(CallableFirstParameterExtractor $parameterExtractor)
-    {
-        return function (callable $handler) use ($parameterExtractor) {
-            return $parameterExtractor->extract($handler);
-        };
-    }
 }


### PR DESCRIPTION
Private method is not used and must be removed.