### PR TITLE
Catch HandlerFailedExceptions on InMemorySymfonyQueryBus.php

### DIFF
--- a/src/Shared/Infrastructure/Bus/Query/InMemorySymfonyQueryBus.php
+++ b/src/Shared/Infrastructure/Bus/Query/InMemorySymfonyQueryBus.php
@@ -8,6 +8,7 @@ use CodelyTv\Shared\Domain\Bus\Query\Query;
 use CodelyTv\Shared\Domain\Bus\Query\QueryBus;
 use CodelyTv\Shared\Domain\Bus\Query\Response;
 use CodelyTv\Shared\Infrastructure\Bus\CallableFirstParameterExtractor;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
 use Symfony\Component\Messenger\Handler\HandlersLocator;
 use Symfony\Component\Messenger\MessageBus;
@@ -36,6 +37,8 @@ final readonly class InMemorySymfonyQueryBus implements QueryBus
 			return $stamp->getResult();
 		} catch (NoHandlerForMessageException) {
 			throw new QueryNotRegisteredError($query);
-		}
+		} catch (HandlerFailedException $error) {
+            throw $error->getPrevious() ?? $error;
+        }
 	}
 }


### PR DESCRIPTION
The InMemorySymfonyQueryBus.php implementation should catch HandlerFailedExceptions to get the throwed exception from the query handler.

This way, ApiExceptionListener can correctly map the status code for the exception. 

Without this fix, all exceptions throwed by the query bus, while the ApiExceptionListener is on, would read as an HandlerFailedException, regardless of the exception mappings defined in the controller.